### PR TITLE
useIsDarkMode

### DIFF
--- a/hooks/useIsDarkMode.ts
+++ b/hooks/useIsDarkMode.ts
@@ -12,7 +12,7 @@ export function useIsDarkMode(override?: boolean) {
   }
 
   React.useEffect(() => {
-    // Don't change theme if on the homepage
+    // Defaults to light mode when on the homepage
     if (router.pathname === '/') {
       setIsDarkMode(false)
       return

--- a/hooks/useIsDarkMode.ts
+++ b/hooks/useIsDarkMode.ts
@@ -1,0 +1,36 @@
+import React from 'react'
+import { useTheme } from 'nextra-theme-docs'
+import { useRouter } from 'next/router'
+
+export function useIsDarkMode(override?: boolean) {
+  const { theme: colorMode } = useTheme()
+  const router = useRouter()
+  const [isDarkMode, setIsDarkMode] = React.useState(colorMode === 'dark' && router.pathname !== '/')
+
+  const darkModeSetter = (event) => {
+    setIsDarkMode(event.matches)
+  }
+
+  React.useEffect(() => {
+    // Don't change theme if on the homepage
+    if (router.pathname === '/') {
+      setIsDarkMode(false)
+      return
+    }
+
+    if (typeof window !== 'undefined') {
+      if (colorMode === 'system') {
+        setIsDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches)
+      } else {
+        const themeInLocalStorage = localStorage.getItem('theme')
+        setIsDarkMode(colorMode ? colorMode === 'dark' : themeInLocalStorage === 'dark')
+      }
+      window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', darkModeSetter)
+    }
+    return () => {
+      window.matchMedia('(prefers-color-scheme: dark)').removeEventListener('change', darkModeSetter)
+    }
+  }, [colorMode, router.pathname, setIsDarkMode])
+
+  return override || isDarkMode
+}

--- a/hooks/useIsDarkMode.ts
+++ b/hooks/useIsDarkMode.ts
@@ -23,6 +23,8 @@ export function useIsDarkMode(override?: boolean) {
         setIsDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches)
       } else {
         const themeInLocalStorage = localStorage.getItem('theme')
+        // colorMode is initially undefined so we check themeInLocalStorage,
+        // but after the first render colorMode takes prescedent
         setIsDarkMode(colorMode ? colorMode === 'dark' : themeInLocalStorage === 'dark')
       }
       window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', darkModeSetter)

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -56,7 +56,9 @@ export default function Nextra({ Component, pageProps }) {
 
       if (currentTheme === 'system') {
         setLightOrDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-      } else {
+
+        // If currentTheme is undefined, we don't need to do anything (browser will handle it)
+      } else if (currentTheme) {
         const newTheme = currentTheme === 'dark' ? 'dark' : 'light'
         setLightOrDarkMode(newTheme)
       }

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -37,14 +37,17 @@ export default function Nextra({ Component, pageProps }) {
 
     if (router.pathname === '/') {
       setLightOrDarkMode('dark')
+
+      // Hide theme button when on landing page
       themeButton.style.display = 'none'
 
-      // override header styles
+      // Override header styles
       headerContainer?.children[0]?.setAttribute(
         'style',
         'box-shadow: none !important; background-color: rgb(23, 23, 23, 0.9) !important;',
       )
     } else {
+      // Reset styles when not on landing page
       themeButton.style.display = 'block'
       headerContainer = window.document?.querySelector('.nextra-nav-container')
       headerContainer?.children[0]?.setAttribute('style', 'box-shadow: initial; background-color: initial;')

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { globalStyles } from '../stitches.config.ts'
+import { globalStyles } from '../stitches.config'
 import { useRouter } from 'next/router'
 import { Prism } from 'prism-react-renderer'
 ;(typeof global !== 'undefined' ? global : window).Prism = Prism
@@ -13,6 +13,7 @@ export default function Nextra({ Component, pageProps }) {
   const router = useRouter()
   let htmlElement: HTMLHtmlElement | null = null
   let headerContainer: HTMLDivElement | null = null
+  let themeButton: HTMLButtonElement | null = null
 
   const setLightOrDarkMode = (mode: 'light' | 'dark') => {
     if (!htmlElement) return
@@ -24,28 +25,37 @@ export default function Nextra({ Component, pageProps }) {
 
   if (typeof window !== 'undefined') {
     htmlElement = window?.document?.querySelector('html')
+    headerContainer = window?.document?.querySelector('.nextra-nav-container')
+    themeButton = window?.document?.querySelector('button[title="Change theme"]')
   }
 
   // Force into dark mode when on landing page
   React.useEffect(() => {
     if (!htmlElement) return
+    if (!themeButton) return
+    if (typeof window === 'undefined') return
+
     if (router.pathname === '/') {
       setLightOrDarkMode('dark')
+      themeButton.style.display = 'none'
 
       // override header styles
-      headerContainer = window?.document?.querySelector('.nextra-nav-container')
       headerContainer?.children[0]?.setAttribute(
         'style',
-        'box-shadow: none !important; background-color: #111111 !important;',
+        'box-shadow: none !important; background-color: rgb(23, 23, 23, 0.9) !important;',
       )
     } else {
-      const currentTheme = localStorage.getItem('theme')
-      headerContainer = window?.document?.querySelector('.nextra-nav-container')
+      themeButton.style.display = 'block'
+      headerContainer = window.document?.querySelector('.nextra-nav-container')
       headerContainer?.children[0]?.setAttribute('style', 'box-shadow: initial; background-color: initial;')
-      if (currentTheme === 'light') {
-        setLightOrDarkMode('light')
+
+      const currentTheme = localStorage.getItem('theme')
+
+      if (currentTheme === 'system') {
+        setLightOrDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
       } else {
-        setLightOrDarkMode('dark')
+        const newTheme = currentTheme === 'dark' ? 'dark' : 'light'
+        setLightOrDarkMode(newTheme)
       }
     }
   }, [router.pathname])


### PR DESCRIPTION
On the docs landing page, we default to light mode, but when the user navigates to the other pages we need to check their color mode. If it is `system`, `useIsDarkMode` checks if the system is in dark mode. 

I also included an `override` boolean because [the header logo text needs to stay in dark](https://github.com/soundxyz/docs/pull/27/files#r1022167343) mode even on the landing page (because the header stays dark), and it is easier to override by passing in a value versus a conditional before calling `useIsDarkMode` (which would break the rules for hooks). 