### PR TITLE
Fixes black-on-black 'Developers' text

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -57,8 +57,6 @@ export default function Nextra({ Component, pageProps }) {
 
       if (!currentTheme || currentTheme === 'system') {
         setLightOrDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
-
-        // If currentTheme is undefined, we don't need to do anything (browser will handle it)
       } else if (currentTheme) {
         const newTheme = currentTheme === 'dark' ? 'dark' : 'light'
         setLightOrDarkMode(newTheme)

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -55,7 +55,7 @@ export default function Nextra({ Component, pageProps }) {
 
       const currentTheme = localStorage.getItem('theme')
 
-      if (currentTheme === 'system') {
+      if (!currentTheme || currentTheme === 'system') {
         setLightOrDarkMode(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
 
         // If currentTheme is undefined, we don't need to do anything (browser will handle it)


### PR DESCRIPTION
To test: set your system preference to light mode, go to docs landing page & click 'View Docs' button