### PR TITLE
chore: fixed broken GoldenEggMetadata link

### DIFF
--- a/pages/protocol/overview/design.mdx
+++ b/pages/protocol/overview/design.mdx
@@ -27,7 +27,7 @@ These are the current set of modules that can be optionally implemented by Sound
 
 #### Metadata modules
 
-- [GoldenEggMetadata](/protocol/modules/golden-egg-metadata) - Implements the Golden Egg used by sound.xyz.
+- [GoldenEggMetadata](/protocol/modules/metadata/golden-egg-metadata) - Implements the Golden Egg used by sound.xyz.
 
 #### Minter modules
 


### PR DESCRIPTION
 Fixed the broken GoldenEggMetadata link from the Design page